### PR TITLE
Remove unused and invalid Geometry task

### DIFF
--- a/SabineMap.js
+++ b/SabineMap.js
@@ -15,7 +15,6 @@ define([
     "esri/SpatialReference",
      "esri/layers/GraphicsLayer",
      "esri/symbols/PictureMarkerSymbol",
-     "esri/tasks/Geometry",
      "esri/geometry/Point",
      "esri/tasks/FeatureSet",
      "esri/layers/FeatureLayer",
@@ -25,7 +24,7 @@ define([
        "dijit/TooltipDialog"
      
 
-], function ($, config,validators,SpatialReference, GraphicsLayer, PictureMarkerSymbol, Geometry, Point, FeatureSet,
+], function ($, config,validators,SpatialReference, GraphicsLayer, PictureMarkerSymbol, Point, FeatureSet,
     FeatureLayer, UniqueValueRenderer, Legend,Extent,TooltipDialog) {
 
     var configVals = dojo.eval(config)[0];

--- a/main.js
+++ b/main.js
@@ -23,12 +23,11 @@ define([
      "esri/layers/FeatureLayer",
      "esri/layers/GraphicsLayer",
      "esri/symbols/PictureMarkerSymbol",
-     "esri/tasks/Geometry",
      "esri/geometry/Point",
       "esri/dijit/Legend"
 ],
     function (declare, PluginBase, $, ui, templates, config,SabineMap,SabineDialog,Salinity,Extent, SpatialReference, FeatureLayer, GraphicsLayer, PictureMarkerSymbol,
-        Geometry,Point,Legend) {
+        Point,Legend) {
 
         var configVals = dojo.eval(config)[0];        
         


### PR DESCRIPTION
`esri/tasks/Geometry` is not a valid task type.  This code could have been
referring to `GeometryService`, but in any event the variable is unused and
has been removed to be compatible with current versions of the framework.

cc/ @dharlan 
